### PR TITLE
Support more recent ActiveFedora usage

### DIFF
--- a/etd_model.gemspec
+++ b/etd_model.gemspec
@@ -11,7 +11,8 @@ Gem::Specification.new do |s|
   s.summary     = 'ETD content model used by the SULAIR Digital Library'
   s.description = 'Contains classes that define the Fedora content model for electronic theses and dissertations.'
 
-  s.add_dependency 'dor-services', '~> 5.13'
+  s.add_dependency 'dor-services', '~> 5.26'
+  s.add_dependency 'active-fedora', '~> 8.4'
 
   s.add_development_dependency 'coveralls'
   s.add_development_dependency 'rake'

--- a/lib/etd_model/etd.rb
+++ b/lib/etd_model/etd.rb
@@ -4,11 +4,11 @@ module EtdModel
     include Dor::Embargoable
     include Dor::Eventable
 
-    has_many 'parts', :property => :is_part_of
-    has_many 'supplemental_files', :property => :is_constituent_of, class_name: 'EtdModel::Part'
-    has_many 'permission_files', :property => :is_dependent_of, class_name: 'EtdModel::Part'
+    has_many :parts, :property => :is_part_of, class_name: 'Part'
+    has_many :supplemental_files, :property => :is_constituent_of, class_name: 'Part'
+    has_many :permission_files, :property => :is_dependent_of, class_name: 'Part'
 
-    has_metadata :name => 'properties', :type => ActiveFedora::SimpleDatastream do |m|
+    has_metadata :name => 'properties', :type => ActiveFedora::SimpleDatastream, :versionable => false do |m|
       m.field 'name',  :string                    # PS:name
       m.field 'prefix', :string                   # PS:prefix
       m.field 'suffix', :string                   # PS:suffix
@@ -54,7 +54,7 @@ module EtdModel
       m.field 'symphonyStatus', :string
     end
 
-    has_metadata :name => 'workflow', :type => ActiveFedora::SimpleDatastream do |m|
+    has_metadata :name => 'workflow', :type => ActiveFedora::SimpleDatastream, :versionable => false do |m|
       m.field 'citation_verified', :string
       m.field 'abstract_provided', :string
       m.field 'dissertation_uploaded', :string
@@ -66,7 +66,6 @@ module EtdModel
       m.field 'submitted_to_registrar', :string
     end
 
-    has_metadata :name => 'DC', :type => ActiveFedora::QualifiedDublinCoreDatastream do |m|
-    end
+    has_metadata :name => 'DC', type: Dor::SimpleDublinCoreDs, versionable: false, label: 'DC', control_group: 'X'
   end
 end

--- a/lib/etd_model/part.rb
+++ b/lib/etd_model/part.rb
@@ -1,16 +1,15 @@
 module EtdModel
   class Part < ActiveFedora::Base
-    belongs_to 'parents', :property => :is_part_of, class_name: 'EtdModel::Etd' # relationship between main pdf and parent etd
-    belongs_to 'supplemental_file_for', :property => :is_constituent_of, class_name: 'EtdModel::Etd' # relationship between supplemental file and parent etd
-    belongs_to 'permission_file_for', :property => :is_dependent_of, class_name: 'EtdModel::Etd'  # relationsihip between permission file and parent etd
+    belongs_to :parents, :property => :is_part_of, class_name: 'Etd' # relationship between main pdf and parent etd
+    belongs_to :supplemental_file_for, :property => :is_constituent_of, class_name: 'Etd' # relationship between supplemental file and parent etd
+    belongs_to :permission_file_for, :property => :is_dependent_of, class_name: 'Etd'  # relationsihip between permission file and parent etd
 
-    has_metadata :name => 'properties', :type => ActiveFedora::SimpleDatastream do |m|
+    has_metadata :name => 'properties', :type => ActiveFedora::SimpleDatastream, :versionable => false do |m|
       m.field 'file_name', :string
       m.field 'size', :string
       m.field 'label', :string
     end
 
-    has_metadata :name => 'DC', :type => ActiveFedora::QualifiedDublinCoreDatastream do |m|
-    end
+    has_metadata :name => 'DC', type: Dor::SimpleDublinCoreDs, versionable: false, label: 'DC', control_group: 'X'
   end
 end


### PR DESCRIPTION
This PR was driven by the ETD work cycle in early 2018, the goal of which was to update the `hydra_etd` app such that it uses somewhat modern dependencies. Part of this work was upgrading the app's ActiveFedora usage from 2.x to the latest 8.x version. In this AF version, relations like `belongs_to` and `has_many` expect their first argument to be a symbol rather than a string.

Additionally:

* `class_name` values including the `EtdModel` namespace caused inverse reflections to break in AF. You can see this was patched around in `etd-robots` earlier, and once this PR is merged, neither `etd-robots` or `hydra_etd` will need local patches to deal with this. See https://github.com/sul-dlss/etd-robots/commit/8052ffea2c7496510d1fe73a842e276abff32fb8#diff-b5d01edc1f6ec3519ee5dc5c4dbc235c
* `workflow` and `properties` datastreams should be unversioned by default (nothing in our stack expects them to be versioning, AFAIK, and the older version of AF didn't yet implement versioning whereas `:versionable` is `true` by default in AF 8.x)
* `DC` datastream should be the Fedora default, which is based on DC11 rather than DCTERMS. This datastream is already defined in `dor-services`. The `hydra_etd` app expects to be able to read and write creator, title, and identifier entries to this datastream.